### PR TITLE
8 custom issue regex

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -78,6 +78,7 @@ export function activate(context: vscode.ExtensionContext) {
 		// === CHECKS FOR STAGED CHANGES ===
 		const staged_files = repo.state.indexChanges;
 
+		// If no changes/files have been staged.
 		if (staged_files.length === 0) {
 			const changes = await repo.diffWithHEAD();
 

--- a/src/steps/issue_number/numberInputBox.ts
+++ b/src/steps/issue_number/numberInputBox.ts
@@ -3,7 +3,7 @@ import createInputBox from "../../createInputBox";
 export default async function numberInputBox(issue_number: string): Promise<string> {
     return await createInputBox({
         title: 'Issue/Ticket Number',
-        placeholder: 'Enter you\'r issue or ticket number',
+        placeholder: 'Enter your issue or ticket number',
         prompt: 'Enter issue or ticket number',
         step: 4,
         value: issue_number


### PR DESCRIPTION
The user can set `simpleCommit.issueRegex` in their settings.json with a custom regex if the default regex doesn't detect their issue number and auto-populate the issue prompt

Closes - #8 