### PR TITLE
feat: :sparkles: #16 - Pass in existing values to functions

### DIFF
--- a/src/createQuickPick.ts
+++ b/src/createQuickPick.ts
@@ -14,29 +14,33 @@ export default function createQuickPick(
 	items: { label: string, detail?: string, description?: string }[],
 	step: number,
 	canSelectMany: boolean,
+	existingValue?: string,
 ): Promise<{ label: string, description: string, detail?: string, }[]> {
 	return new Promise((resolve, reject) => {
 		let current = 0;
-	
+
 		const quickPick = vscode.window.createQuickPick();
 		quickPick.title = title;
 		quickPick.placeholder = placeholder;
-	
+		if (existingValue) {
+			quickPick.value = existingValue;
+		}
+
 		quickPick.items = items;
 		quickPick.activeItems = [quickPick.items[current]];
-	
+
 		quickPick.step = step;
 		quickPick.totalSteps = TOTAL_STEPS;
 		quickPick.ignoreFocusOut = true;
 		quickPick.canSelectMany = canSelectMany;
 		quickPick.matchOnDetail = true;
-	
+
 		quickPick.buttons = [
 			...(step > 1 ? [vscode.QuickInputButtons.Back] : [])
 		];
 
 		let selected: any = [];
-	
+
 		quickPick.onDidChangeSelection((selection) => {
 			selected = selection;
 		});
@@ -48,8 +52,8 @@ export default function createQuickPick(
 		quickPick.onDidAccept(() => {
 			resolve(selected);
 		});
-	
-	
+
+
 		quickPick.show();
 	});
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -153,14 +153,14 @@ export function activate(context: vscode.ExtensionContext) {
 			const step = step_order[current_step];
 			switch (step) {
 				case '<type>':
-					await typeQuickPick()
+					await typeQuickPick(type)
 						.then((value: string) => {
 							type = value;
 							current_step++;
 						});
 					break;
 				case '<scope>':
-					await chosenScope(workspace_config)
+					await chosenScope(workspace_config, scope)
 						.then((value: string) => {
 							scope = value;
 							current_step++;
@@ -168,7 +168,7 @@ export function activate(context: vscode.ExtensionContext) {
 						.catch(() => current_step--);
 					break;
 				case '<emoji>':
-					await emojiQuickPick()
+					await emojiQuickPick(emoji)
 						.then((value) => {
 							emoji = value;
 							current_step++;
@@ -176,7 +176,7 @@ export function activate(context: vscode.ExtensionContext) {
 						.catch(() => current_step--);
 					break;
 				case '<number>':
-					await numberInputBox(issue_number)
+					await numberInputBox(issue_number, ticket_number)
 						.then((value: string) => {
 							ticket_number = value;
 							current_step++;
@@ -184,7 +184,7 @@ export function activate(context: vscode.ExtensionContext) {
 						.catch(() => current_step--);
 					break;
 				case '<description>':
-					await descriptionInputBox()
+					await descriptionInputBox(description)
 						.then((value: string) => {
 							description = value;
 							current_step++;
@@ -192,7 +192,7 @@ export function activate(context: vscode.ExtensionContext) {
 						.catch(() => current_step--);
 					break;
 				case '<body>':
-					await bodyInputBox()
+					await bodyInputBox(body)
 						.then((value: string) => {
 							body = value;
 							current_step++;
@@ -200,7 +200,7 @@ export function activate(context: vscode.ExtensionContext) {
 						.catch(() => current_step--);
 					break;
 				case '<footer>':
-					await footerInputBox()
+					await footerInputBox(footer)
 						.then((value: string) => {
 							footer = value;
 							current_step++;

--- a/src/steps/body/bodyInputBox.ts
+++ b/src/steps/body/bodyInputBox.ts
@@ -1,10 +1,11 @@
 import createInputBox from "../../createInputBox";
 
-export default async function bodyInputBox(): Promise<string> {
+export default async function bodyInputBox(existingBody: string): Promise<string> {
     return await createInputBox({
         title: 'Body',
         placeholder: 'Enter a detailed description of this commit.',
         prompt: 'Enter a detailed description of this commit.',
-        step: 6
+        step: 6,
+        value: existingBody
     });
 }

--- a/src/steps/description/descriptionInputBox.ts
+++ b/src/steps/description/descriptionInputBox.ts
@@ -1,10 +1,11 @@
 import createInputBox from "../../createInputBox";
 
-export default async function descriptionInputBox(): Promise<string> {
+export default async function descriptionInputBox(existingDescription: string): Promise<string> {
     return await createInputBox({
         title: 'Description',
         placeholder: 'Enter a short description of this commit.',
         prompt: 'Enter a short description of this commit.',
-        step: 5
+        step: 5,
+        value: existingDescription
     });
 }

--- a/src/steps/emoji/emojiQuickPick.ts
+++ b/src/steps/emoji/emojiQuickPick.ts
@@ -2,15 +2,15 @@ import createQuickPick from '../../createQuickPick';
 const gitmojis: {
     $schema: string,
     gitmojis: {
-      emoji: string;
-      entity: string;
-      code: string;
-      description: string;
-      name: string;
+        emoji: string;
+        entity: string;
+        code: string;
+        description: string;
+        name: string;
     }[];
 } = require('../../vendors/gitmojis.json');
 
-export default async function emojiQuickPick(): Promise<string> {
+export default async function emojiQuickPick(exitingEmoji: string): Promise<string> {
     const emojis = gitmojis.gitmojis;
 
     const items = emojis.map((obj) => ({
@@ -19,13 +19,14 @@ export default async function emojiQuickPick(): Promise<string> {
         detail: obj.description
     }));
 
-	const selected_emoji = await createQuickPick(
-		'Emoji', // title
-		'Select an emoji for your commit.', // placeholder
-		items, // items
-		3, // step
+    const selected_emoji = await createQuickPick(
+        'Emoji', // title
+        'Select an emoji for your commit.', // placeholder
+        items, // items
+        3, // step
         false, // canSelectMany
-	);
+        exitingEmoji,
+    );
 
     return selected_emoji[0].description;
 }

--- a/src/steps/footer/footerInputBox.ts
+++ b/src/steps/footer/footerInputBox.ts
@@ -1,10 +1,11 @@
 import createInputBox from "../../createInputBox";
 
-export default async function footerInputBox(): Promise<string> {
+export default async function footerInputBox(existingFooter: string): Promise<string> {
     return await createInputBox({
         title: 'Footer',
         placeholder: 'Enter remaining information such as Breaking Changes details about this commit.',
         prompt: 'Enter a footer.',
-        step: 6
+        step: 6,
+        value: existingFooter
     });
 }

--- a/src/steps/issue_number/numberInputBox.ts
+++ b/src/steps/issue_number/numberInputBox.ts
@@ -1,11 +1,15 @@
 import createInputBox from "../../createInputBox";
 
-export default async function numberInputBox(issue_number: string): Promise<string> {
+export default async function numberInputBox(
+    issue_number: string,
+    existingNumber: string
+): Promise<string> {
+    const value = existingNumber.length > 0 ? issue_number : existingNumber;
     return await createInputBox({
         title: 'Issue/Ticket Number',
         placeholder: 'Enter your issue or ticket number',
         prompt: 'Enter issue or ticket number',
         step: 4,
-        value: issue_number
+        value
     });
 }

--- a/src/steps/scope/chosenScope.ts
+++ b/src/steps/scope/chosenScope.ts
@@ -3,16 +3,19 @@ import scopeQuickPick from './scopeQuickPick';
 import newScopeInputBox from './newScopeInputBox';
 import oneTimeScopeInputBox from './oneTimeScopeInputBox';
 
-export default async function chosenScope(workspace_config: vscode.WorkspaceConfiguration): Promise<string> {
+export default async function chosenScope(
+    workspace_config: vscode.WorkspaceConfiguration,
+    existingValue: string
+): Promise<string> {
     return new Promise((resolve, reject) => {
         const saved_scopes: string[] = workspace_config.get('scopes') as unknown as string[];
-    
-        scopeQuickPick(saved_scopes)
+
+        scopeQuickPick(saved_scopes, existingValue)
             .then(async (value) => {
                 const scope_type = value;
-            
+
                 if (scope_type === 'New Scope') {
-                    const new_scope = await newScopeInputBox();
+                    const new_scope = await newScopeInputBox(existingValue);
                     if (new_scope) {
                         await workspace_config.update('scopes', [...saved_scopes, new_scope], vscode.ConfigurationTarget.Workspace);
                         resolve(new_scope);
@@ -20,7 +23,7 @@ export default async function chosenScope(workspace_config: vscode.WorkspaceConf
                         resolve('');
                     }
                 } else if (scope_type === 'One Time Scope') {
-                    const one_time_scope = await oneTimeScopeInputBox();
+                    const one_time_scope = await oneTimeScopeInputBox(existingValue);
                     resolve(one_time_scope);
                 } else if (scope_type === 'None') {
                     resolve('');

--- a/src/steps/scope/newScopeInputBox.ts
+++ b/src/steps/scope/newScopeInputBox.ts
@@ -1,10 +1,11 @@
 import createInputBox from "../../createInputBox";
 
-export default async function newScopeInputBox(): Promise<string> {
+export default async function newScopeInputBox(existingValue: string): Promise<string> {
     return await createInputBox({
         title: 'New Scope',
         placeholder: 'Enter a name for your new scope.',
         prompt: 'Enter new scope name.',
         step: 2,
+        value: existingValue
     });
 }

--- a/src/steps/scope/oneTimeScopeInputBox.ts
+++ b/src/steps/scope/oneTimeScopeInputBox.ts
@@ -1,10 +1,11 @@
 import createInputBox from "../../createInputBox";
 
-export default async function oneTimeScopeInputBox(): Promise<string> {
+export default async function oneTimeScopeInputBox(existingValue: string): Promise<string> {
     return await createInputBox({
         title: 'One Time Scope',
         placeholder: 'Enter the scope name.',
         prompt: 'Enter scope name.',
         step: 2,
+        value: existingValue,
     });
 }

--- a/src/steps/scope/scopeQuickPick.ts
+++ b/src/steps/scope/scopeQuickPick.ts
@@ -1,9 +1,12 @@
 import createQuickPick from '../../createQuickPick';
 
-export default async function scopeQuickPick(saved_scopes: string[]): Promise<string> {
+export default async function scopeQuickPick(
+	saved_scopes: string[],
+	existingValue: string
+): Promise<string> {
 	return new Promise(async (resolve, reject) => {
 		const scope_options = [{ label: 'None', description: 'No scope.' }];
-	
+
 		if (saved_scopes) {
 			const formatted_scopes = saved_scopes.map((str) => ({
 				label: str,
@@ -25,6 +28,7 @@ export default async function scopeQuickPick(saved_scopes: string[]): Promise<st
 				scope_options, // items
 				2, // step
 				false, // canSelectMany
+				existingValue,
 			);
 
 			resolve(selected_scope[0].label);

--- a/src/steps/type/typeQuickPick.ts
+++ b/src/steps/type/typeQuickPick.ts
@@ -1,6 +1,6 @@
 import createQuickPick from '../../createQuickPick';
 
-export default async function typeQuickPick(): Promise<string> {
+export default async function typeQuickPick(existingValue: string): Promise<string> {
 	const available_types = [
 		{ label: 'feat', description: 'Feature', detail: "A new feature" },
 		{ label: 'fix', description: 'Bug Fix', detail: 'A bug fix' },
@@ -18,6 +18,7 @@ export default async function typeQuickPick(): Promise<string> {
 		available_types, // items
 		1, // step
 		false, // canSelectMany
+		existingValue,
 	);
 
 	return selected_type[0].label;


### PR DESCRIPTION
These changes allow the extension to remember what the user previously entered. Example, if they entered a description then went to the next step, then went back to edit the description, the user wouldn't have to remember what they previously entered to edit it. I have passed in the existing values to the prompts.