### PR TITLE
fix: :bug: #20 - Use the `workingTreeChanges` instead of the diff wit…

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,7 +50,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 		// If no changes/files have been staged.
 		if (staged_files.length === 0) {
-			const changes = await repo.diffWithHEAD();
+			const changes = repo.state.workingTreeChanges;
 
 			let changed_files: QuickPickItemsType[] = [];
 


### PR DESCRIPTION
Doing this gets all changes, including untracked, so the user can add modified and newly added files.