### PR TITLE
#25 have the generated commit message show within the source control input box

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,11 @@
           "type": "string",
           "default": "code",
           "description": "By what attribute you filter the emoji list."
+        },
+        "simpleCommit.showCommit": {
+          "type": "boolean",
+          "default": false,
+          "description": "Show your commit message within the Source Control tab."
         }
       }
     },

--- a/src/buildCommitMessage.ts
+++ b/src/buildCommitMessage.ts
@@ -14,13 +14,13 @@ export default async function buildCommitMessage(
     workspace_config: WorkspaceConfiguration,
     repo: Repositories,
 ) {
-    const workspace_reference_regex = workspace_config.get('referenceRegex') as string;
+    const workspace_reference_regex = workspace_config.get<string>('referenceRegex');
 
-    const workspace_disable_emoji = workspace_config.get('disableEmoji') as boolean;
-    const workspace_disable_reference = workspace_config.get('disableReference') as boolean;
-    const workspace_disable_description = workspace_config.get('disableDescription') as boolean;
-    const workspace_disable_body = workspace_config.get('disableBody') as boolean;
-    const workspace_disable_footer = workspace_config.get('disableFooter') as boolean;
+    const workspace_disable_emoji = workspace_config.get<boolean>('disableEmoji');
+    const workspace_disable_reference = workspace_config.get<boolean>('disableReference');
+    const workspace_disable_description = workspace_config.get<boolean>('disableDescription');
+    const workspace_disable_body = workspace_config.get<boolean>('disableBody');
+    const workspace_disable_footer = workspace_config.get<boolean>('disableFooter');
 
     let message_values = {
         type: '',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,7 +24,7 @@ export function activate(context: vscode.ExtensionContext) {
 		const workspace_config = vscode.workspace.getConfiguration('simpleCommit');
 
 		// === WORKSPACE EXTENSION VALUES ===
-		const workspace_commit_template = workspace_config.get('template') as string;
+		const workspace_commit_template = workspace_config.get<string>('template');
 
 		// === INITIATE GIT ===
 		const repo = initiateGit();
@@ -69,9 +69,12 @@ export function activate(context: vscode.ExtensionContext) {
 
 		console.log('Commit Message:', `\n\n${commit_message}`);
 
-		// await vscode.commands.executeCommand('workbench.view.scm');
-		// // How to get commit message into the Source Control input box
-		// repo.inputBox.value = commit_message;
+		// === SHOW COMMIT MESSAGE IN SCM ===
+		const workspace_show_commit = workspace_config.get<boolean>('showCommit');
+		if (workspace_show_commit) {
+			await vscode.commands.executeCommand('workbench.view.scm');
+			repo.inputBox.value = commit_message;
+		}
 
 		// === COMMIT ===
 		repo.commit(commit_message)

--- a/src/steps/emoji/emojiQuickPick.ts
+++ b/src/steps/emoji/emojiQuickPick.ts
@@ -13,7 +13,7 @@ const gitmojis: {
 } = require('../../vendors/gitmojis.json');
 
 export default async function emojiQuickPick(exitingEmoji: string, workspace_config: WorkspaceConfiguration): Promise<string> {
-    const workspace_commit_emojiFilter: "description" | "code" = workspace_config.get('emojiFilter') as "description" | "code";
+    const workspace_commit_emojiFilter = workspace_config.get<"description" | "code">('emojiFilter');
 
     const emojis = gitmojis.gitmojis;
 

--- a/src/steps/scope/chosenScope.ts
+++ b/src/steps/scope/chosenScope.ts
@@ -8,7 +8,8 @@ export default async function chosenScope(
     existing_value: string
 ): Promise<string> {
     return new Promise((resolve, reject) => {
-        const saved_scopes: string[] = workspace_config.get('scopes') as unknown as string[];
+        const config_scopes = workspace_config.get<string[]>('scopes');
+        const saved_scopes = config_scopes ?? [];
 
         scopeQuickPick(saved_scopes, existing_value)
             .then(async (value) => {

--- a/src/steps/scope/scopeQuickPick.ts
+++ b/src/steps/scope/scopeQuickPick.ts
@@ -7,16 +7,14 @@ export default async function scopeQuickPick(
 	return new Promise(async (resolve, reject) => {
 		const scope_options = [{ label: 'None', description: 'No scope.' }];
 
-		if (saved_scopes) {
-			const formatted_scopes = saved_scopes.map((str) => ({
-				label: str,
-				description: '',
-				detail: 'From saved scopes.'
-			}));
-			for (let i = 0; i < formatted_scopes.length; i++) {
-				const formatted_scope = formatted_scopes[i];
-				scope_options.push(formatted_scope);
-			}
+		const formatted_scopes = saved_scopes.map((str) => ({
+			label: str,
+			description: '',
+			detail: 'From saved scopes.'
+		}));
+		for (let i = 0; i < formatted_scopes.length; i++) {
+			const formatted_scope = formatted_scopes[i];
+			scope_options.push(formatted_scope);
 		}
 		scope_options.push({ label: 'New Scope', description: 'Add a new scope to your workspace to reuse in the future.' });
 		scope_options.push({ label: 'One Time Scope', description: 'Enter a scope that won\'t get saved to your workspace.' });

--- a/src/types/git.ts
+++ b/src/types/git.ts
@@ -14,6 +14,9 @@ export type Repositories = {
     };
     add: (file_paths: (string | undefined)[]) => void;
     commit: (message: string) => Promise<void>;
+    inputBox: {
+        value: string;
+    };
 };
 
 export type GetAPI = {


### PR DESCRIPTION
if user enables `showCommit` in their `settings.json` the commit message will appear in the inputbox on the Source Control tab