### PR TITLE
fix: :bug: #50 - added reference step when selecting common commit

### DIFF
--- a/src/buildCommitMessage.ts
+++ b/src/buildCommitMessage.ts
@@ -52,6 +52,16 @@ export default async function buildCommitMessage(
     chosen_common_commit = await commonCommitQuickPick();
 
     if (chosen_common_commit !== undefined) {
+        if (step_order.includes("<reference>")) {
+            // As the reference is dynamic we need to display the input box to the user
+            // so it gets added to the commit message
+            const head = repo.state.HEAD;
+            const reference = getReference(workspace_reference_regex, head);
+            await referenceInputBox(reference, message_values.reference)
+                .then((value: string) => {
+                    message_values.reference = value;
+                });
+        }
         message_values = {
           ...message_values, // Keep existing message_values as base
           ...chosen_common_commit, // Override with any matching fields from chosen_common_commit


### PR DESCRIPTION
fixed the issue when selecting a common commit, the reference is empty. the reference step will now run so the user can double check the reference being added is correct

Fixes #50 